### PR TITLE
changes to page layouts, theorem boxes, and some commands

### DIFF
--- a/tex/lecture_01.tex
+++ b/tex/lecture_01.tex
@@ -7,8 +7,9 @@
 
 \begin{document}
 \section{An axiomatic definition of the natural numbers}
-We begin with a set called $\N$.
-We know nothing about it yet, but we will assume these three properties to be axiomatic:
+We begin with a nonempty set called $\N$.
+We know what it should look like, but how can we precisely define it?
+Assuming we know nothing about it except that it exists, we will state three axiomatic properties that it should have:
 \begin{enumerate}[label=\textbf{a\arabic*)}]
     \item $1 \in \N$.\footnote{
         The standard axiomatization of $\N$ starts with $0$, but we start with $1$ to simplify our approach in constructing $\R$.
@@ -30,12 +31,13 @@ Let $\N$ be a set containing $1$ and equipped with a function $S: \N \rightarrow
     \item If $A \subseteq \N$ is a set such that $1 \in A$ and $S(A) \subseteq A$, then $A = \N$.
 \end{enumerate}
 
-The formal link between these sets of axioms is the definition $S(n) := n + 1$, which we call a \emph{successor function}.
-The latter set gives the standard axiomatization of the natural numbers known as the \emph{Peano axioms}.\footnote{
+The formal link between these sets of axioms is the definition $S(n) := n + 1$, which we call a successor function.
+The latter set gives the standard axiomatization of the natural numbers known as the Peano axioms.\footnote{
     Named in honor of Giuseppe Peano, 1858--1932.
 }
-\begin{definition}{Peano axioms}{peano-axioms}
-    $\N$ is a set called the \textbf{natural numbers}, equipped with a function $S: \N \rightarrow \N$.
+
+\begin{definition}[title=Natural numbers, label=naturals]
+    The \emph{natural numbers} $\N$ are a set equipped with a successor function $S: \N \rightarrow \N$ and that satisfies the \emph{Peano axioms:}
     \begin{enumerate}
         \item $1 \in \N$.
         \item $S(\N) = \N \setminus \set{1}$.
@@ -52,7 +54,7 @@ This is further explored in the exercises.
 
     \subsection*{Exercises}
     \begin{exercises}
-        \item Let $\N$ be the natural numbers given by the Peano axioms in \Cref{def:peano-axioms}.
+        \item Let $\N$ be the natural numbers given by the Peano axioms in \Cref{def:naturals}.
         Prove that $S$ is injective if and only if $\N$ is not a finite set.
 
         \item Prove that the fourth Peano axiom implies the principle of mathematical induction:\footnote{

--- a/tex/lecture_02.tex
+++ b/tex/lecture_02.tex
@@ -8,178 +8,179 @@
 \begin{document}
 \section{Constructing the integers and rational numbers}
     \subsection{Relations}
-        Let $X$ be any set.
-        A \textbf{relation} $R$ on $X$ is a particular subset $R \subset X \times X$ that is
-        \begin{itemize}
-            \item \textbf{reflexive} if $\forall x \in X$ $(x, x) \in R$;
-            \item \textbf{symmetric} if $\forall x, y \in X$ $(x, y) \in R \iff (y, x) \in R$;
-            \item \textbf{transitive} if $\forall x, y, z \in X$ $\left[ (x, y) \in R \text{ and } (y, z) \in R \right] \implies (x, z) \in R$.
-        \end{itemize}
-        The statement $(x, y) \in R$ is read ``$x$ is \emph{related} to $y$.''
-        Alternatively, we write this as $x R y$ or $x \sim y$.
+    Let $X$ be any set.
+    A \emph{relation} $R$ on $X$ is a particular subset $R \subset X \times X$ that is
+    \begin{itemize}
+        \item \emph{reflexive} if $\forall x \in X$ $(x, x) \in R$;
+        \item \emph{symmetric} if $\forall x, y \in X$ $(x, y) \in R \iff (y, x) \in R$;
+        \item \emph{transitive} if $\forall x, y, z \in X$ $\left[ (x, y) \in R \text{ and } (y, z) \in R \right] \implies (x, z) \in R$.
+    \end{itemize}
+    The statement $(x, y) \in R$ is read ``$x$ is \emph{related} to $y$.''
+    Alternatively, we write this as $x R y$ or $x \sim y$.
 
-        $R$ is called an \textbf{equivalence relation} if it is reflexive, symmetric, and transitive.
-        For any equivalence relation $R$ on a set $X$, we define the \emph{equivalence class} of $x \in X$ to be the set of all elements of $X$ that are related to $x$,
+    $R$ is called an \emph{equivalence relation} if it is reflexive, symmetric, and transitive.
+    For any equivalence relation $R$ on a set $X$, we define the \emph{equivalence class} of $x \in X$ to be the set of all elements of $X$ that are related to $x$,
+    \[
+        \eqclass{x} = \set[y \in X]{x \sim y}
+    ,\]
+    where $\eqclass{\cdot}: X \rightarrow 2^X$ is a mapping from $x$ to its equivalence class.
+    The set of all equivalence classes under the relation is the image of $X$ under $\eqclass{\cdot}$,
+    \[
+        \faktor{X}{\sim} = \eqclass{X} \subset 2^X  
+    .\]
+
+    \begin{remark}
+        Let $X$ be any set with $\sim$ an equivalence relation on $X$.
+        Then
         \[
-            \eqclass{x} = \set{y \in X \mid x \sim y}
+            X = \bigsqcup_{Y \in \nicefrac{X}{\sim}} Y  
         ,\]
-        where $\eqclass{\cdot}: X \rightarrow 2^X$ is a mapping from $x$ to its equivalence class.
-        The set of all equivalence classes is the image of $X$ under $\eqclass{\cdot}$,
-        \[
-            \faktor{X}{\sim} = \eqclass{X} \subset 2^X  
-        .\]
+        i.e.\ the equivalence relation $\sim$ partitions $X$ into a disjoint collection of equivalence classes.
+        \tcblower
+        \begin{proof}
+            Let $Y, Z \subset X$ be equivalence classes.
+            Note that equivalence classes are nonempty since equivalence relations are reflexive, so it suffices to prove that if $Y \cap Z \neq \emptyset$, then $Y = Z$.
 
-        \begin{remark}
-            Let $X$ be any set with $\sim$ an equivalence relation on $X$.
-            Then
+            Let $x_0 \in Y \cap Z$, $x_1 \in Y$, and $x_2 \in Z$.
+            Then $x_0 \sim x_1$ and $x_0 \sim x_2$, so by symmetry and transitivity we have $x_1 \sim x_2$.
+            This implies that 
             \[
-                X = \bigsqcup_{Y \in \nicefrac{X}{\sim}} Y  
-            ,\]
-            i.e.\ the equivalence relation $\sim$ partitions $X$ into a disjoint collection of equivalence classes.
-            \hr{}
-            \begin{proof}
-                Let $Y, Z \subset X$ be equivalence classes.
-                Note that equivalence classes are nonempty since equivalence relations are reflexive, so it suffices to prove that if $Y \cap Z \neq \emptyset$, then $Y = Z$.
+                Y = \eqclass{x_1} = \eqclass{x_2} = Z
+            \]
+            as desired.
+        \end{proof}
+    \end{remark}
 
-                Let $x_0 \in Y \cap Z$, $x_1 \in Y$, and $x_2 \in Z$.
-                Then $x_0 \sim x_1$ and $x_0 \sim x_2$, so by symmetry and transitivity we have $x_1 \sim x_2$.
-                This implies that 
-                \[
-                    Y = \eqclass{x_1} = \eqclass{x_2} = Z
-                \]
-                as desired.
-            \end{proof}
-        \end{remark}
+    \begin{figure}[ht]
+        \centering
+        \incfig{1.2-set-partition}
+        \caption{A set $X$ partitioned by an equivalence relation $\sim$ into pairwise disjoint equivalence classes $Y_i$.}
+    \end{figure}
 
-        \begin{figure}[ht]
-            \centering
-            \incfig{1.2-set-partition}
-            \caption{A set $X$ partitioned by an equivalence relation $\sim$ into pairwise disjoint equivalence classes $Y_i$.}
-        \end{figure}
+    Although we have not yet formally introduced $\Z$, consider the following example from abstract algebra:
 
-        Although we have not yet formally introduced $\Z$, consider the following example from abstract algebra:
+    \begin{example}
+        Fix $n \in \N$.
+        We say for any $a, b \in \Z$ that $a \sim b$ if $n \mid a - b$.
+        Then $a$ is \emph{congruent} to $b$ modulo $n$, or $a \equiv b \Mod{n}$.
+        Congruence modulo $n$ is an equivalence relation on $\Z$, and the ring $\Z_n$ (also denoted $\Z/n\Z$) is the set of equivalence classes under this relation:
+        \begin{align*}
+            \Z_2 &= \set{\eqclass{0}, \eqclass{1}} \\
+            \Z_3 &= \set{\eqclass{0}, \eqclass{1}, \eqclass{{2}}} \\
+            &\vdotswithin{=} \\
+            \Z_n &= \set{\eqclass{0}, \eqclass{1}, \eqclass{2}, \dots, \eqclass{n - 1}} \\
+            &\vdotswithin{=}
+        \end{align*}
+    \end{example}
 
-        \begin{example}{}{}
-            Fix $n \in \N$.
-            We say for any $a, b \in \Z$ that $a \sim b$ if $n \mid a - b$.
-            Then $a$ is \emph{congruent} to $b$ modulo $n$, or $a \equiv b \mod{n}$.
-            Congruence modulo $n$ is an equivalence relation on $\Z$, and the ring $\Z_n$ is the set of equivalence classes under this relation:
-            \begin{align*}
-                \Z_2 &= \set{\eqclass{0}, \eqclass{1}} \\
-                \Z_3 &= \set{\eqclass{0}, \eqclass{1}, \eqclass{{2}}} \\
-                &\vdotswithin{=} \\
-                \Z_n &= \set{\eqclass{0}, \eqclass{1}, \eqclass{2}, \dots, \eqclass{n - 1}} \\
-                &\vdotswithin{=}
-            \end{align*}
-        \end{example}
 
     \subsection{Grothendieck groups}
-        Recall that a \emph{semigroup} is an algebraic structure consisting of a set together with an associative binary operation.
-        Our definition of $\N$ equipped with $+$ constitutes a semigroup, so we now introduce commutative semigroups with cancellation.
-        \begin{definition}{Commutative semigroup with cancellation}{commutative-cancellative-semigroup}
-            $(S, +)$ is a \textbf{commutative semigroup} if, for all $a, b, c \in S$, we have
-            \begin{itemize}
-                \item $(a + b) + c = a + (b + c)$,
-                \item $a + b = b + a$.
-            \end{itemize}
-            $(S, +)$ has the \textbf{cancellation property} if, for all $a, b, c \in S$,
+    Recall that a \emph{semigroup} is an algebraic structure consisting of a set together with an associative binary operation.
+    Our definition of $\N$ equipped with $+$ constitutes a semigroup, so we now introduce commutative semigroups with cancellation.
+    \begin{definition}[title=Commutative semigroup with cancellation, label=commutative-cancellative-semigroup]
+        $(S, +)$ is a \emph{commutative semigroup} if, for all $a, b, c \in S$, we have
+        \begin{itemize}
+            \item $(a + b) + c = a + (b + c)$,
+            \item $a + b = b + a$.
+        \end{itemize}
+        $(S, +)$ has the \emph{cancellation property} if, for all $a, b, c \in S$,
+        \[
+            a + c = b + c \implies a = b
+        .\]
+    \end{definition}
+
+    \begin{lemma}[label=n-additive-cancellation]
+        $(\N, +)$ has the cancellation property.
+        \tcblower
+        \begin{proof}
+            Let $A(m)$ be the statement
             \[
-                a + c = b + c \implies a = b
+                \forall k, l \in \N \quad k + m = l + m \implies k = l
+            ,\]
+            and we will prove by induction that $A(m)$ holds for all $m \in \N$.
+            When $m = 1$ we have
+            \[
+                k + 1 = l + 1 \iff S(k) = S(l)  
+            ,\]
+            which implies $k = l$ since $S$ is injective.
+
+            Now assume $A(m)$ is true for some $m \geq 1$.
+            Let $k, l \in \N$ satisfy
+            \[
+                k + (m + 1) = l + (m + 1)
             .\]
-        \end{definition}
+            Then by associativity and the induction hypothesis,
+            \begin{align*}
+                (k + m) + 1 = (l + m) + 1 &\xRightarrow{A(1)} k + m = l + m \\
+                &\xRightarrow{A(m)} k = l.
+            \end{align*}
+        \end{proof}
+    \end{lemma}
 
-        \begin{lemma}{}{n-additive-cancellation}
-            $(\N, +)$ has the cancellation property.
-            \hr{}
-            \begin{proof}
-                Let $A(m)$ be the statement
-                \[
-                    \forall k, l \in \N \quad k + m = l + m \implies k = l
-                ,\]
-                and we will prove by induction that $A(m)$ holds for all $m \in \N$.
-                When $m = 1$ we have
-                \[
-                    k + 1 = l + 1 \iff S(k) = S(l)  
-                ,\]
-                which implies $k = l$ since $S$ is injective.
+    Recall that an \emph{abelian group} is a group whose operation is commutative:
+    \begin{definition}[title=Abelian group, label=abelian-group]
+        $(G, \circ, 1)$ is an \emph{abelian group} if it satisfies:
+        \begin{itemize}
+            \item \eqmakebox[abelianAxioms][l]{$1 \circ g = g \circ 1 = g$} \emph{identity}
+            \item \eqmakebox[abelianAxioms][l]{$(g \circ h) \circ k = g \circ (h \circ k)$} \emph{associativity}
+            \item \eqmakebox[abelianAxioms][l]{$\forall g \: \exists! \, h$ such that $g \circ h = h \circ g = 1$ \qquad\qquad} \emph{invertibility}
+            \item \eqmakebox[abelianAxioms][l]{$g \circ h = h \circ g$} \emph{commutativity}
+        \end{itemize}
+    \end{definition}
+    As we will now see, abelian groups are central to our construction of $\R$ through the construction of \emph{Grothendieck groups}.\footnote{
+        Construction of such groups first introduced by Alexander Grothendieck, 1928--2014.
+    }
 
-                Now assume $A(m)$ is true for some $m \geq 1$.
-                Let $k, l \in \N$ satisfy
-                \[
-                    k + (m + 1) = l + (m + 1)
-                .\]
-                Then by associativity and the induction hypothesis,
-                \begin{align*}
-                    (k + m) + 1 = (l + m) + 1 &\xRightarrow{A(1)} k + m = l + m \\
-                    &\xRightarrow{A(m)} k = l.
-                \end{align*}
-            \end{proof}
-        \end{lemma}
+    \begin{lemma}[title=Grothendieck lemma, label=grothendieck-lemma]
+        Let $(S, +)$ be a nonempty commutative semigroup with cancellation.
+        Then there exists a smallest abelian group containing $S$ called the \emph{Grothendieck group} for $S$.
+        \tcblower
+        \begin{proof}
+            We first construct an abelian group $G$ from $S$.
+            For any $a, b, c, d \in S$, define the relation $(a, b) \sim (c, d)$ if and only if $a + d = b + c$.\footnote{
+                This idea comes from fractions: $\frac{a}{b} = \frac{c}{d} \iff ad = bc$, but our operation is additive rather than multiplicative.
+            }
+            Indeed, this is an equivalence relation on $S$.
+            For transitivity, assume $(a, b) \sim (c, d) \sim (e, f)$.
+            Then
+            \begin{align*}
+                \left.\begin{aligned}
+                    a + d &= b + c \\
+                    c + f &= d + e
+                \end{aligned}\right\}
+                &\implies a + d + c + f = b + c + d + e \\
+                &\implies a + f = b + e \\
+                &\implies (a, b) \sim (e, f).
+            \end{align*}
+            Try proving reflexivity and symmetry for practice.
 
-        Recall that an \emph{abelian group} is a group whose operation is commutative:
-        \begin{definition}{Abelian group}{abelian-group}
-            $(G, \circ, 1)$ is an \textbf{abelian group} if it satisfies:
-            \begin{itemize}
-                \item \eqmakebox[abelianAxioms][l]{$1 \circ g = g \circ 1 = g$} \emph{identity}
-                \item \eqmakebox[abelianAxioms][l]{$(g \circ h) \circ k = g \circ (h \circ k)$} \emph{associativity}
-                \item \eqmakebox[abelianAxioms][l]{$\forall g \: \exists! \, h$ such that $g \circ h = h \circ g = 1$ \qquad\qquad} \emph{invertibility}
-                \item \eqmakebox[abelianAxioms][l]{$g \circ h = h \circ g$} \emph{commutativity}
-            \end{itemize}
-        \end{definition}
-        As we will now see, abelian groups are central to our construction of $\R$ through the construction of \emph{Grothendieck groups}.\footnote{
-            Construction of such groups first introduced by Alexander Grothendieck, 1928--2014.
-        }
+            Now let $G := \nicefrac{(S \times S)}{\sim}$ be equipped with the binary operation $+$ defined by
+            \[
+                \eqclass{(a, b)} + \eqclass{(c, d)} := \eqclass{(a + c), (b + d)}
+            .\]
+            This operation is well-defined and clearly associative and commutative; proofs of these claims are also left to the reader.
 
-        \begin{lemma}{Grothendieck lemma}{grothendieck-lemma}
-            Let $(S, +)$ be a nonempty commutative semigroup with cancellation.
-            Then there exists a smallest abelian group containing $S$, called the \textbf{Grothendieck group} for $S$.
-            \hr{}
-            \begin{proof}
-                We first construct an abelian group $G$ from $S$.
-                For any $a, b, c, d \in S$, define the relation $(a, b) \sim (c, d)$ if and only if $a + d = b + c$.\footnote{
-                    This idea comes from fractions: $\frac{a}{b} = \frac{c}{d} \iff ad = bc$, but our operation is additive rather than multiplicative.
-                }
-                Indeed, this is an equivalence relation on $S$.
-                For transitivity, assume $(a, b) \sim (c, d) \sim (e, f)$.
-                Then
-                \begin{align*}
-                    \left.\begin{aligned}
-                        a + d &= b + c \\
-                        c + f &= d + e
-                    \end{aligned}\right\}
-                    &\implies a + d + c + f = b + c + d + e \\
-                    &\implies a + f = b + e \\
-                    &\implies (a, b) \sim (e, f).
-                \end{align*}
-                Proof of reflexivity and symmetry is left to the reader.
+            To confirm that $G$ is a group, it remains to show that $G$ has an identity element and unique inverses.
+            For the former, fix any $a \in S$.
+            Note that for all $a, b, c \in S$, $(a, a) \sim (b, b)$ since $a + b = a + b$; and
+            \[
+                \eqclass{(a, a)} + \eqclass{(b, c)} = \eqclass{(a + b, a + c)} = \eqclass{(b, c)}  
+            \]
+            because $a + b + c = a + c + b$.
+            Thus, $\eqclass{(a, a)} = 0$ is an identity for $G$.
 
-                Now let $G := \nicefrac{(S \times S)}{\sim}$ be equipped with the binary operation $+$ defined by
-                \[
-                    \eqclass{(a, b)} + \eqclass{(c, d)} := \eqclass{(a + c), (b + d)}    
-                .\]
-                This operation is well-defined and clearly associative and commutative; proofs of these claims are also left to the reader.
+            For inverses, consider any $\eqclass{(a, b)} \in G$.
+            Take $\eqclass{(b, a)}$ so that
+            \[
+                \eqclass{(a, b)} + \eqclass{(b, a)} = \eqclass{(a + b, a + b)} = 0
+            ,\]
+            hence $\eqclass{(a, b)}$ is invertible.
+            Proof of uniqueness is left to the reader.
 
-                To confirm that $G$ is a group, it remains to show that $G$ has an identity element and unique inverses.
-                For the former, fix any $a \in S$.
-                Note that for all $a, b, c \in S$, $(a, a) \sim (b, b)$ since $a + b = a + b$; and
-                \[
-                    \eqclass{(a, a)} + \eqclass{(b, c)} = \eqclass{(a + b, a + c)} = \eqclass{(b, c)}  
-                \]
-                because $a + b + c = a + c + b$.
-                Thus, $\eqclass{(a, a)} = 0$ is an identity for $G$.
+            So far, we have shown that $G$ is indeed an abelian group.
+            Proof that $G$ contains $S$ and is the \emph{smallest} such abelian group is covered in the exercises.
+        \end{proof}
+    \end{lemma}
 
-                For inverses, consider any $\eqclass{(a, b)} \in G$.
-                Take $\eqclass{(b, a)}$ so that
-                \[
-                    \eqclass{(a, b)} + \eqclass{(b, a)} = \eqclass{(a + b, a + b)} = 0
-                ,\]
-                hence $\eqclass{(a, b)}$ is invertible.
-                Proof of uniqueness is left to the reader.
-
-                So far, we have shown that $G$ is indeed an abelian group.
-                Proof that $G$ contains $S$ and is the \emph{smallest} such abelian group is covered in the exercises.
-            \end{proof}
-        \end{lemma}
-
-        Naturally, our interest in the Grothendieck lemma is in constructing the integers and the rational numbers from the natural numbers.
+    Naturally, our interest in the Grothendieck lemma is in constructing the integers and the rational numbers from the natural numbers.
 \end{document}

--- a/tex/lecture_03.tex
+++ b/tex/lecture_03.tex
@@ -6,7 +6,7 @@
 % \input{./preamble.tex}
 
 \begin{document}
-\subsection{Integers and rationals as Grothendieck groups}
+    \subsection{Integers and rationals as Grothendieck groups}
     The Grothendieck lemma states that for any commutative semigroup with cancellation, $(S, +)$, we can construct a Groenthdieck group $G(S)$ for $S$ by defining
     \[
         G(S) := \faktor{(S \times S)}{\sim}
@@ -22,7 +22,7 @@
 
     \begin{remark}
         Define the order relation $<$ on $\N$ by saying $n < n'$ if there exists $k \in \N$ such that $n' = n + k$.
-        This relation satisfies the \emph{trichotomy law}: For any $n, n' \in \N$, exactly one of the following holds:
+        This relation satisfies the \emph{trichotomy law:} For all $n, n' \in \N$, exactly one of the following holds:
         \begin{enumerate}
             \item $n < n'$
             \item $n' < n$
@@ -30,9 +30,9 @@
         \end{enumerate}
     \end{remark}
 
-    \begin{lemma}{}{n-multiplicative-cancellation}
+    \begin{lemma}[label=n-multiplicative-cancellation]
         $(\N, \mult{})$ has the cancellation property.
-        \hr{}
+        \tcblower
         \begin{proof}
             Let $B(m)$ be the statement
             \[
@@ -65,12 +65,12 @@
         \end{proof}
     \end{lemma}
 
-    We are now ready for a formal definition of the \textbf{integers}, $\Z$.
+    We are now ready for a formal definition of the \emph{integers} $\Z$.
     The integers are the smallest abelian group containing $\N$ equipped with addition; $\Z$ is the Grothendieck group for $(\N, +)$ given by
     \begin{align*}
         \Z &:= G(\N, +) \\
         &= \faktor{(\N \times \N)}{\sim} \\
-        &= \left( \N \times \set{+} \right) \cup \left( \N \times \set{-} \right) \cup \set{0},
+        &:= \left( \N \times \set{+} \right) \cup \left( \N \times \set{-} \right) \cup \set{0},
     \end{align*}
     where each integer is an equivalence class denoted by
     \[
@@ -85,16 +85,16 @@
     
     So what Grothendieck groups can be constructed from $(\N, \mult{})$ and $\Z$?
     The answer, perhaps unsurprisingly, is the \emph{rational numbers}.
-    \begin{definition}{Rational numbers}{rational-numbers}
-        The \textbf{positive rationals} are defined by
+    \begin{definition}[title=Rational numbers, label=rational-numbers]
+        The \emph{positive rationals} $\Q^{+}$ are defined by
         \[
-            \Q^{+} := G(\N, \mult{}) = \set{\frac{p}{q} : p, q \in \N}
+            \Q^{+} := G(\N, \mult{}) = \set[\frac{p}{q}]{p, q \in \N}
         .\]
-        The \textbf{rationals} can be equivalently defined by two Grothendieck groups:
+        The \emph{rationals} $\Q$ can be equivalently defined by two Grothendieck groups:
         \begin{align*}
             \Q &:= G(\Q^{+}, +) \quad \text{where} \quad \frac{p}{q} + \frac{p'}{q'} = \frac{pq' + p'q}{qq'}
             \intertext{and}
-            \Q &:= G(\Z \setminus \set{0}, \mult{}) = \set{\frac{p}{q} : p \in \Z, q \in \N}.
+            \Q &:= G(\Z \setminus \set{0}, \mult{}) = \set[\frac{p}{q}]{p \in \Z, q \in \N}.
         \end{align*}
     \end{definition}
 
@@ -113,8 +113,8 @@
         \begin{tabularx}{\textwidth}{p{0.45\linewidth} p{0.45\linewidth}}
             \textbf{Field axioms} & \textbf{Order axioms} \\
             \begin{itemize}[topsep=0pt]
-                \item $(\Q, +, 0)$ is an abelian group.
-                \item $(\Q \setminus \set{0}, \mult{}, 1)$ is an abelian group.
+                \item $(\Q, +, 0)$ is abelian.
+                \item $(\Q \setminus \set{0}, \mult{}, 1)$ is abelian.
                 \item $a \cdot (b + c) = a \cdot b + a \cdot c$.
             \end{itemize} &
             \begin{itemize}[topsep=0pt]
@@ -126,116 +126,116 @@
     \end{figure*}
 
     More generally, ordered fields allow us to introduce the concept of \emph{upper bounds} and \emph{least upper bounds}.
-    \begin{definition}{(Least) upper bound}{lub}
+    \begin{definition}[title=(Least) upper bound, label=lub]
         Let $F$ be an ordered field.
         Given $A \subseteq F$ and $b \in F$:
         \begin{enumerate}
-            \item $b$ is an \textbf{upper bound} for $A$ if $a \leq b$ for all $a \in A$.
+            \item $b$ is an \emph{upper bound} for $A$ if $a \leq b$ for all $a \in A$.
             This is also denoted by $A \leq b$.
-            \item $b$ is a \textbf{least upper bound} if $A \leq b$ and $b \leq b'$ for any upper bound $b'$.
-            This is called the \textbf{supremum} of $A$, denoted by $\sup{A}$.
+            \item $b$ is a \emph{least upper bound} if $A \leq b$ and $b \leq b'$ for any upper bound $b'$.
+            This is called the \emph{supremum} of $A$, denoted by $\sup{A}$.
         \end{enumerate}
     \end{definition}
 
-    \begin{figure}
+    \begin{figure}[ht]
         \centering
         \incfig{1.3-upper-bound}
         \caption{$A$ is bounded above both by $b = \sup{A}$ and $b'$. Note that the supremum of a set need not necessarily belong to the set.}
     \end{figure}
 
     The supremum will be key to our discussion of completeness, which is a concept we introduce here for ordered fields.
-    \begin{definition}{Complete ordered field}{complete-ordered-field}
-        An ordered field $F$ is called \textbf{complete} if for every nonempty subset $A \subset F$ there exists $b' \in F$ such that $A \leq b'$, then there exists $b \in F$ such that $b = \sup{A}$.
+    \begin{definition}[title=Complete ordered field, label=complete-ordered-field]
+        An ordered field $F$ is called \emph{complete} if for every nonempty subset $A \subset F$ there exists $b' \in F$ such that $A \leq b'$, then there exists $b \in F$ such that $b = \sup{A}$.
         In other words, every set $A$ bounded above has a supremum $b$.
     \end{definition}
 
-    \begin{example}{}{}
-        $\set{x \in \Q : x^2 < 2}$ has no supremum in $\Q$, so $\Q$ is not complete.
+    \begin{example}
+        $\set[x \in \Q]{x^2 < 2}$ has no supremum in $\Q$, so $\Q$ is not complete.
     \end{example}
 
     Recall from the start of the chapter our prior definitions of $\R$ as a unique complete and ordered field as well as a particular subset of $2^{\Q}$.
     Now that we have working definitions of both complete ordered fields and $\Q$, we can properly construct $\R$.
 
 
-\subsection*{Exercises}
-\begin{exercises}
-    \item A \emph{totally ordered semigroup} is a semigroup $(A, +)$ with an order relation $\leq$ that satisfies the following properties for all $a, b, c \in A$:
-    \begin{itemize}
-        \item $a \leq a$;
-        \item $a \leq b, \ b \leq a \implies a = b$;
-        \item $a \leq b, \ b \leq c \implies a \leq c$;
-        \item $a \leq b$ or $b \leq a$;
-        \item $a \leq b \implies a + c \leq b + c$.
-    \end{itemize}
+    \subsection*{Exercises}
     \begin{exercises}
-        \item Give a definition for a total order $\leq$ on $\N$ such that $n \leq S(n)$ for all $n$.
-        Prove that the above properties hold.
-        \item Prove that if $x \leq y$, then there exists a unique $z \in \N$ such that $x + z = y$.
-    \end{exercises}
+        \item A \emph{totally ordered semigroup} is a semigroup $(A, +)$ with an order relation $\leq$ that satisfies the following properties for all $a, b, c \in A$:
+        \begin{itemize}
+            \item $a \leq a$;
+            \item $a \leq b, \ b \leq a \implies a = b$;
+            \item $a \leq b, \ b \leq c \implies a \leq c$;
+            \item $a \leq b$ or $b \leq a$;
+            \item $a \leq b \implies a + c \leq b + c$.
+        \end{itemize}
+        \begin{exercises}
+            \item Give a definition for a total order $\leq$ on $\N$ such that $n \leq S(n)$ for all $n$.
+            Prove that the above properties hold.
+            \item Prove that if $x \leq y$, then there exists a unique $z \in \N$ such that $x + z = y$.
+        \end{exercises}
 
-    \item In this exercise, we finish the proof of the \nameref{lem:grothendieck-lemma}.
-    Let $S$ be a commutative semigroup with cancellation and $G(S)$ its Grothendieck group.
-    \begin{exercises}
-        \item Prove that the function $\iota : S \rightarrow G(S)$ defined by $s \mapsto \eqclass{(s + s, s)}$ is injective and satisfies $\iota(s + t) = \iota(s) + \iota(t)$ for all $s, t \in S$.\footnote{
-            This shows that $\iota$ is an injective homomorphism that embeds $S$ into $G(S)$, hence $G(S)$ ``contains'' $S$ as $\iota(S)$.
-        }
-        \item Let $(G, \mult{})$ be a group and $\phi : S \rightarrow G$ a function such that $\phi(x + y) = \phi(x) \cdot \phi(y)$.
-        Prove that there is a function $\psi : G(S) \rightarrow G$ such that $\psi \circ \iota = \phi$ and $\psi(g + h) = \psi(g) \cdot \psi(h)$ for all $g, h \in G(S)$.\footnote{
-            This shows that $G(S)$ is the ``smallest'' abelian group containing $S$.
-        }
-    \end{exercises}
+        \item In this exercise, we finish the proof of the \nameref{lem:grothendieck-lemma}.
+        Let $S$ be a commutative semigroup with cancellation and $G(S)$ its Grothendieck group.
+        \begin{exercises}
+            \item Prove that the function $\iota : S \rightarrow G(S)$ defined by $s \mapsto \eqclass{(s + s, s)}$ is injective and satisfies $\iota(s + t) = \iota(s) + \iota(t)$ for all $s, t \in S$.\footnote{
+                This shows that $\iota$ is an injective homomorphism that embeds $S$ into $G(S)$, hence $G(S)$ ``contains'' $S$ as $\iota(S)$.
+            }
+            \item Let $(G, \mult{})$ be a group and $\phi : S \rightarrow G$ a function such that $\phi(x + y) = \phi(x) \cdot \phi(y)$.
+            Prove that there is a function $\psi : G(S) \rightarrow G$ such that $\psi \circ \iota = \phi$ and $\psi(g + h) = \psi(g) \cdot \psi(h)$ for all $g, h \in G(S)$.\footnote{
+                This shows that $G(S)$ is the ``smallest'' abelian group containing $S$.
+            }
+        \end{exercises}
 
-    \item Let $(S, +, \leq)$ be a totally ordered commutative semigroup with cancellation.
-    Define an order relation $\leq$ on its Grothendieck group $G(S)$ by
-    \[
-        \eqclass{(a, b)} \leq \eqclass{(c, d)} \iff a + d \leq b + c
-    .\]
-    Prove that
-    \begin{exercises}
-        \item $\forall s, t, c \in S \quad s + c \leq t + c \implies s \leq t$;
-        \item $\forall s,t \in S \quad \eqclass{(s + s, s)} \leq \eqclass{(t + t, t)} \iff s \leq t$;
-        \item $(G(S), \leq)$ is a totally ordered group.
-    \end{exercises}
-    
-    \item Given the Grothendieck group definition of $\Z$, define addition in $\Z$ as follows:
-    \begin{align*}
-        0 + z = z + 0 &= z \quad \forall z \in \Z \\
-        (x, +) + (y, +) &= (x + y, +) \\
-        (x, -) + (y, -) &= (x + y, -) \\
-        (x, +) + (y, -) &=
-        \begin{cases}
-            (x - y, +) &\text{if } y < x \\
-            (y - x, -) &\text{if } x < y \\
-            \hfil 0 &\text{if } x = y.
-        \end{cases}
-    \end{align*}
-    \begin{exercises}
-        \item Prove that the function $\phi : G(\N, +) \rightarrow \Z$ defined by
+        \item Let $(S, +, \leq)$ be a totally ordered commutative semigroup with cancellation.
+        Define an order relation $\leq$ on its Grothendieck group $G(S)$ by
         \[
-            \phi\left(\eqclass{a, b}\right) =
+            \eqclass{(a, b)} \leq \eqclass{(c, d)} \iff a + d \leq b + c
+        .\]
+        Prove that
+        \begin{exercises}
+            \item $\forall s, t, c \in S \quad s + c \leq t + c \implies s \leq t$;
+            \item $\forall s,t \in S \quad \eqclass{(s + s, s)} \leq \eqclass{(t + t, t)} \iff s \leq t$;
+            \item $(G(S), \leq)$ is a totally ordered group.
+        \end{exercises}
+        
+        \item Given the Grothendieck group definition of $\Z$, define addition in $\Z$ as follows:
+        \begin{align*}
+            0 + z = z + 0 &= z \quad \forall z \in \Z \\
+            (x, +) + (y, +) &= (x + y, +) \\
+            (x, -) + (y, -) &= (x + y, -) \\
+            (x, +) + (y, -) &=
             \begin{cases}
-                (a - b, +) &\text{if } b < a \\
-                (b - a, -) &\text{if } a < b \\
-                \hfil 0 &\text{if } a = b
+                (x - y, +) &\text{if } y < x \\
+                (y - x, -) &\text{if } x < y \\
+                \hfil 0 &\text{if } x = y.
             \end{cases}
-        \]
-        is bijective and satisfies $\phi\left(\eqclass{a + c, b + d}\right) = \phi\left(\eqclass{a, b}\right) + \phi\left(\eqclass{c, d}\right)$.
+        \end{align*}
+        \begin{exercises}
+            \item Prove that the function $\phi : G(\N, +) \rightarrow \Z$ defined by
+            \[
+                \phi\left(\eqclass{a, b}\right) =
+                \begin{cases}
+                    (a - b, +) &\text{if } b < a \\
+                    (b - a, -) &\text{if } a < b \\
+                    \hfil 0 &\text{if } a = b
+                \end{cases}
+            \]
+            is bijective and satisfies $\phi\left(\eqclass{a + c, b + d}\right) = \phi\left(\eqclass{a, b}\right) + \phi\left(\eqclass{c, d}\right)$.
 
-        \item For $x, y \in \Z$, define $x \leq y$ to mean $\phi^{-1}(x) \leq \phi^{-1}(y)$.
-        Prove that $(a, +) > 0$ and $(a, -) < 0$ for all $a \in \N$.
-    \end{exercises}
+            \item For $x, y \in \Z$, define $x \leq y$ to mean $\phi^{-1}(x) \leq \phi^{-1}(y)$.
+            Prove that $(a, +) > 0$ and $(a, -) < 0$ for all $a \in \N$.
+        \end{exercises}
 
-    \item Define multiplication in $\Z$ as follows:
-    \begin{align*}
-        0 \cdot z = z \cdot 0 &= 0 \quad \forall z \in \Z \\
-        (x, +) \cdot (y, +) &= (x \cdot y, +) \\
-        (x, -) \cdot (y, -) &= (x \cdot y, +) \\
-        (x, +) \cdot (y, -) &= (x \cdot y, -) \\
-        (x, -) \cdot (y, +) &= (x \cdot y, -)
-    \end{align*}
-    \begin{exercises}
-        \item Prove that $(\Z \setminus \set{0}, \mult{})$ is a commutative semigroup with cancellation.
-        \item $(\Z, +)$ is a totally ordered group, so verify that $a, b > 0 \implies ab > 0$.
+        \item Define multiplication in $\Z$ as follows:
+        \begin{align*}
+            0 \cdot z = z \cdot 0 &= 0 \quad \forall z \in \Z \\
+            (x, +) \cdot (y, +) &= (x \cdot y, +) \\
+            (x, -) \cdot (y, -) &= (x \cdot y, +) \\
+            (x, +) \cdot (y, -) &= (x \cdot y, -) \\
+            (x, -) \cdot (y, +) &= (x \cdot y, -)
+        \end{align*}
+        \begin{exercises}
+            \item Prove that $(\Z \setminus \set{0}, \mult{})$ is a commutative semigroup with cancellation.
+            \item $(\Z, +)$ is a totally ordered group, so verify that $a, b > 0 \implies ab > 0$.
+        \end{exercises}
     \end{exercises}
-\end{exercises}
 \end{document}

--- a/tex/lecture_04.tex
+++ b/tex/lecture_04.tex
@@ -9,8 +9,8 @@
 \section{Real numbers as Dedekind cuts}
 Now we can construct $\R$ in a way that shows it to be both a complete, ordered field and a subset of $2^{\Q}$ by using \emph{Dedekind cuts}.
 
-\begin{definition}{Dedekind cut}{dedekind-cut}
-    A \textbf{Dedekind cut} is a set $A \subseteq \Q$ such that:
+\begin{definition}[title=Dedekind cut, label=dedekind-cut]
+    A \emph{Dedekind cut} is a set $A \subseteq \Q$ such that:
     \begin{itemize}
         \item $\forall a \in A \quad b \leq a \implies b \in A$.
         \item $\forall a \in A \quad \exists a' > a$ such that $a' \in A$.
@@ -21,8 +21,8 @@ The first condition says a Dedekind cut is open downward, i.e.\ it continues to 
 The second condition says it is open upward, i.e.\ it has no maximal element in the cut.
 (Note that this does not necessarily mean it goes to $\infty$).
 
-\begin{example}{}{r-dedekind}
-    Let $R := \set{D \subseteq \Q : D \text{ is Dedekind}}$ and define $\phi : \Q \rightarrow R$ by $q \mapsto \set{a : a < q}$.
+\begin{example}[label=r-dedekind]
+    Let $R := \set[D \subseteq \Q]{D \text{ is Dedekind}}$ and define $\phi : \Q \rightarrow R$ by $q \mapsto \set[a \in \Q]{a < q}$.
     Then $R$ is Dedekind.
 \end{example}
 
@@ -35,8 +35,8 @@ Every rational to the left of $q$ is in the cut $D$, and no matter which $a \in 
     \caption{A Dedekind cut at $q$. The real line has infinitely many ``holes'' at the irrationals; the purpose of Dedekind cuts is to fill those holes.}
 \end{figure}
 
-\begin{example}{}{sqrt-2-dedekind}
-    $A_{\sqrt{2}} := \set{x \in \Q : x^2 < 2 \text{ or } x \leq 0}$ is Dedekind.
+\begin{example}[label=sqrt-2-dedekind]
+    $A_{\sqrt{2}} := \set[x \in \Q]{x^2 < 2 \text{ or } x \leq 0}$ is Dedekind.
 \end{example}
 
 Try showing that these example sets satisfy \Cref{def:dedekind-cut}.
@@ -44,14 +44,14 @@ Try showing that these example sets satisfy \Cref{def:dedekind-cut}.
 Since $\Q$ is totally ordered, \Cref{ex:r-dedekind} suggests that we can also order Dedekind cuts.
 Indeed, this shows us that that set $R$ of Dedekind cuts is complete.
 
-\begin{definition}{}{}
+\begin{definition}
     Let $D_1, D_2 \in R$.
     If $D_1 \subseteq D_2$, then we say $D_1 \leq D_2$.
 \end{definition}
 
-\begin{lemma}{}{set-of-dedekind-complete}
+\begin{lemma}[label=set-of-dedekind-complete]
     $R$ is complete.
-    \hr{}
+    \tcblower
     \begin{proof}
         Let $S \subset R$ be a nonempty set of Dedekind cuts and let $D \in R$ be an upper bound for $S$.
         Then for every $s \in S$, by definition $s \leq D$ and $s \subseteq D$.
@@ -71,22 +71,22 @@ Not quite, because this set is too big!
 Note that $\Q$ itself is a Dedekind cut in $R$ that would correspond to $\infty$, which we know is not a number.
 Hence, we refine our definition of $R$ to give a proper definition of the \emph{real numbers}.
 
-\begin{definition}{Real numbers}{}
-    The \textbf{real numbers} $\R$ are the set of proper Dedekind cuts
+\begin{definition}[title=Real numbers]
+    The \emph{real numbers} $\R$ are the set of proper Dedekind cuts
     \[
-        \R := \set{D \subset \Q : D \neq \Q \text{ is Dedekind}}
+        \R := \set[D \subset \Q]{D \neq \Q \text{ is Dedekind}}
     .\]
     If $D \neq \Q$, then take any $q \notin D$.
     No $q' > q$ can be in $D$, so we can equivalently define $\R$ by
     \[
-       \R := \set{D \in R : \exists q \in \Q \text{ such that } D < \phi(q)}
+       \R := \set[D \in R]{\exists q \in \Q \text{ such that } D < \phi(q)}
     ,\]
     where $\phi : \Q \rightarrow \R$ is analagously defined as in \Cref{ex:r-dedekind}.
 \end{definition}
 
 \begin{remark}
     $\R$ is complete.
-    \hr{}
+    \tcblower
     \begin{proof}
         If $D \in \R$, then by definition there exists $q_0$ such that $D < \phi(q_0)$.
         This implies
@@ -100,9 +100,9 @@ Hence, we refine our definition of $R$ to give a proper definition of the \emph{
 \hr{}
 
 We now consider the field nature of $\R$.
-Define the \textbf{positive reals} $\R^{+}$ as the set
+Define the \emph{positive reals} $\R^{+}$ as the set
 \[
-    \R^{+} := \set{D \in \R : (-\infty, 0] \subseteq D}
+    \R^{+} := \set[D \in \R]{(-\infty, 0] \subseteq D}
 ,\]
 and define addition and multiplication in it by
 \begin{align*}
@@ -110,8 +110,7 @@ and define addition and multiplication in it by
     D_1 D_2 &= \bigcup \set{d_1 d_2 : d_1 \in D_1^{+}, d_2 \in D_2^{+}}.
 \end{align*}
 Since negative numbers complicate multiplication, we can assume that $D \in \R^{+}$ is a subset of $\Q^{+}$ and ``starts'' at $0$ rather than $-\infty$.
-More formally, we can view this as $\R^{+} = \set{D \subset \Q^{+} : D \cup (-\infty, 0] \text{ is Dedekind}}$.
-
+More formally, we can view this as $\R^{+} = \set[D \subset \Q^{+}]{D \cup (-\infty, 0] \text{ is Dedekind}}$.
 
 With these operations, $\R^{+}$ satisfies the field axioms with associative, commutative, and distributive properties (verify these for practice!):
 \begin{align*}
@@ -125,9 +124,9 @@ Our final answer to what the real numbers are is that $\R$ is the Grothendieck g
     \R = G(\R^{+}, +)
 .\]
 
-\begin{lemma}{}{}
+\begin{lemma}
     $\R$ is totally ordered.
-    \hr{}
+    \tcblower
     \begin{proof}
         Let $D_1, D_2 \in \R$.
         There are two cases:
@@ -147,7 +146,7 @@ Our final answer to what the real numbers are is that $\R$ is the Grothendieck g
     \begin{exercises}
         \item Let $\phi : \Q^{+} \rightarrow \R^{+}$ (where $\R^{+}$ is a set of Dedekind cuts) be the function defined by
         \[
-            \phi(q) := \set{a \in \Q : a < q}
+            \phi(q) := \set[a \in \Q]{a < q}
         .\]
         \begin{exercises}
             \item Prove that $\phi$ is injective and order-preserving, i.e.\ show that if $q < q'$, then $\phi(q) < \phi(q')$.

--- a/tex/lecture_05.tex
+++ b/tex/lecture_05.tex
@@ -34,15 +34,15 @@
 
     \subsection{The reals are uncountable}
     To prove this property, we first prove the uncountability of the power set of $\N$.
-    \begin{lemma}{}{power-n-uncountable}
+    \begin{lemma}[label=power-n-uncountable]
         $2^{\N}$ is uncountable.
-        \hr{}
+        \tcblower
         \begin{proof}
             Assume toward contradiction that $2^{\N}$ is countable.
             Then there exists a bijection $\phi : \N \rightarrow 2^{\N}$.
             Define the set
             \[
-                B := \set{n \in \N : n \notin \phi(n)} \subset \N  
+                B := \set[n \in \N]{n \notin \phi(n)} \subset \N  
             .\]
             Since $B \in 2^{\N}$ and $\phi$ is bijective, there exists $m \in \N$ such that $\phi(m) = B$.
             Then there are two possible cases:
@@ -93,7 +93,7 @@
             B & 0 & 1 & 0 & 0 & 1 & \cdots
         \end{array}
     \]
-    Without loss of generality, let $m_0 = \min{\set{m \in A : m \notin B}}$, i.e.\ $m_0$ is the first number where the two sets disagree.
+    Without loss of generality, let $m_0 = \min{\set[m \in A]{m \notin B}}$, i.e.\ $m_0$ is the first number where the two sets disagree.
     So for every $j < m_0$, both $j \in A$ and $j \in B$.
     Then
     \[
@@ -126,9 +126,9 @@
     .\]\qed
     
     This result now shows us that the real numbers are indeed uncountable.
-    \begin{theorem}{}{r-uncountable}
+    \begin{theorem}[label=r-uncountable]
         $\R$ is uncountable.
-        \hr{}
+        \tcblower
         \begin{proof}
             Let $\phi : 2^{\N} \rightarrow [0, 1]$ be defined as before.
             Assume toward contradiction that $\R$ is countable.

--- a/tex/master.tex
+++ b/tex/master.tex
@@ -1,9 +1,9 @@
 % !TeX program = lualatex
 % !TeX encoding = utf-8
 
-\documentclass[11pt,notitlepage]{report}
-\input{./preamble.tex}
+\documentclass[11pt,twoside,notitlepage]{report}
 \usepackage{subfiles}
+\input{./preamble.tex}
 
 \title{Real Analysis}
 \date{}
@@ -15,7 +15,7 @@
     \begin{abstract}
         These are my course notes for Real Variables (MATH 447), which I took at the University of Illinois Urbana--Champaign as instructed by Marius Junge.
         The course is a careful development of elementary real analysis for those who intend to take graduate courses in mathematics.
-        It covers, with a fair amount of abstraction and numerous proofs,
+        It covers, with a fair amount of abstraction and numerous proofs:
         \begin{itemize}[noitemsep]
             \item Real numbers
             \item Sequences
@@ -25,7 +25,7 @@
             \item Integration
         \end{itemize}
 
-        I adapted the 447 lectures and course material to create this personal reference for my future studies.
+        I adapted the 447 lectures and course material for personal reference.
         All credit for the exercises goes to Jason Elliot; the selected solutions are my own.
         I take all responsibility for any mistakes in the text.
         Please contact me for corrections or questions through my \href{https://ericmordonez.com}{website}.
@@ -33,7 +33,7 @@
         Last updated: \today.
     \end{abstract}
 
-    \tableofcontents
+    {\sffamily\tableofcontents}
     \thispagestyle{empty}
 
     % Begin lectures

--- a/tex/preamble.tex
+++ b/tex/preamble.tex
@@ -1,4 +1,4 @@
-% MATH PACKAGES
+% MATH PACKAGES ===============================================================
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{amsthm}
@@ -22,43 +22,49 @@
 \let\epsilon\varepsilon
 \let\phi\varphi
 \renewcommand{\vec}[1]{\bm{#1}}
-\renewcommand\qedsymbol{$\blacksquare$}
+\renewcommand{\qedsymbol}{$\blacksquare$}
 
 % Math operator declarations and commands
-\DeclareMathOperator{\Ima}{Im}
 \DeclareMathOperator{\dis}{d}
 \DeclareMathOperator{\Lim}{Lim}
 \DeclareMathOperator{\interior}{Int}
 
-\DeclarePairedDelimiter\abs{\lvert}{\rvert}
 \makeatletter
+\DeclarePairedDelimiter\abs{\lvert}{\rvert}
 \let\oldabs\abs
 \def\abs{\@ifstar{\oldabs}{\oldabs*}}
 
-\DeclarePairedDelimiter\set{\{}{\}}
-\makeatletter
-\let\oldset\set
-\def\set{\@ifstar{\oldset}{\oldset*}}
+\DeclarePairedDelimiter\setc{\{}{\}}
+\let\oldset\setc
+\def\setc{\@ifstar{\oldset}{\oldset*}}
+
+\newcommand{\set}[2][\@empty]{%
+    \ifx\@empty#1
+        \setc{\,#2\,}
+    \else
+        \setc{\,#1 \;\middle|\; #2\,}
+    \fi
+}
+\makeatother
 
 \newcommand{\eqclass}[1]{\left[ #1 \right]}
 \newcommand{\mult}{{}\cdot{}}
 \newcommand{\Mod}[1]{\ (\mathrm{mod}\ #1)}
 
 
-% FORMATTING PACKAGES
-\usepackage[left=1.5in,right=1.5in,top=1in,bottom=1in]{geometry}
+% FORMATTING PACKAGES =========================================================
+\usepackage[top=1in,right=1.5in,bottom=1in,left=1.5in,asymmetric]{geometry}
+\setlength{\marginparwidth}{2cm}
 % \usepackage{parskip}
 \usepackage{textcomp}
 \usepackage{eqparbox}
 \usepackage{float}
 \usepackage{graphicx}
-\usepackage{xcolor}
+\usepackage{xcolor-material}
 \usepackage{enumitem}
 \usepackage{emptypage}
 \usepackage{microtype}
 \usepackage{tabularx}
-\usepackage{todonotes}
-\setlength{\marginparwidth}{2cm}
 \usepackage[pdfpagelabels]{hyperref}
 \usepackage[capitalise,noabbrev]{cleveref}
 \usepackage{nameref}
@@ -71,73 +77,88 @@
 }
 
 
-% ENVIRONMENTS
+% ENVIRONMENTS ================================================================
 \usepackage[most]{tcolorbox}
-\tcbuselibrary{theorems, breakable}
-\theoremstyle{definition}
+\tcbuselibrary{breakable, theorems}
+
+\ExplSyntaxOn
+\NewDocumentCommand{\betternewtcbtheorem}{O{}mmmm}{%
+    \newtcbtheorem[#1]{#2inner}{#3}{#4}{#5}
+    \NewDocumentEnvironment{#2}{O{}}{%
+        \keys_set:nn { hushus/tcb } { ##1 }
+        \hushus_tcb_begin:nVV {#2inner} \l__hushus_tcb_title_tl \l__hushus_tcb_label_tl
+    }{%
+        \end{#2inner}
+    }
+    \cs_if_exist:cF { c@#5 } { \newcounter{#5} }
+}
+\cs_new_protected:Nn \hushus_tcb_begin:nnn {%
+    \begin{#1}{#2}{#3}}
+\cs_generate_variant:Nn \hushus_tcb_begin:nnn { nVV }
+\keys_define:nn { hushus/tcb }{%
+    title .tl_set:N = \l__hushus_tcb_title_tl,
+    label .tl_set:N = \l__hushus_tcb_label_tl,
+}
+\ExplSyntaxOff
 
 \tcbset{
-    thmbox/.style={
-        enhanced,
+    thmtitle/.style={
+        attach title to upper=\\[0.5em]
+    },
+    remtitle/.style={
+        attach title to upper=\quad
+    },
+    thmbox/.style 2 args={
+        enhanced jigsaw,
         breakable,
         sharp corners,
-        borderline west={2pt}{0pt}{#1},
+        skin=bicolor,
+        borderline west={3pt}{0pt}{#1},
         boxrule=0pt,
         fonttitle=\sffamily\bfseries,
-        coltitle=black,
+        description font=\sffamily\mdseries,
+        description delimiters={(}{)},
+        description color=#1,
+        separator sign={\ },
+        coltitle=#1,
         colframe=#1,
-        colback=white!95!#1,
-        colbacktitle=white!75!#1,
-        bottomtitle=-0.5pt,
+        colback=#2,
+        colbacklower=white,
         parbox=false,
         before skip=1.5em,
         after skip=1.5em
     }
 }
 
-\newtcbtheorem[number within=chapter]{definition}{Definition}{
+\betternewtcbtheorem[number within=chapter]{definition}{Definition}{
+    thmtitle,
     label type=definition,
-    thmbox=blue!75!white
+    thmbox={MaterialBlue700}{MaterialBlue50},
 }{def}
-\newtcbtheorem[number within=chapter]{theorem}{Theorem}{
+\betternewtcbtheorem[number within=chapter]{theorem}{Theorem}{
+    thmtitle,
     label type=theorem,
-    thmbox=red!75!white
+    thmbox={MaterialPurple700}{MaterialPurple50}
 }{thm}
-\newtcbtheorem[number within=chapter]{lemma}{Lemma}{
+\betternewtcbtheorem[number within=chapter]{lemma}{Lemma}{
+    thmtitle,
     label type=lemma,
-    thmbox=red!75!white
+    thmbox={MaterialDeepOrange700}{MaterialDeepOrange50}
 }{lem}
-\newtcbtheorem[number within=chapter]{proposition}{Proposition}{
+\betternewtcbtheorem[number within=chapter]{proposition}{Proposition}{
+    thmtitle,
     label type=proposition,
-    thmbox=red!75!white
+    thmbox={MaterialDeepOrange700}{MaterialDeepOrange50}
 }{prop}
-\newtcbtheorem[number within=chapter]{example}{Example}{
-    label type=ex,
-    enhanced jigsaw,
-    breakable,
-    sharp corners,
-    borderline west={2pt}{0pt}{black!75!white},
-    boxrule=0pt,
-    fonttitle=\sffamily\bfseries,
-    coltitle=black,
-    attach title to upper={\quad},
-    parbox=false,
-    before skip=1.5em,
-    after skip=1.5em
+\betternewtcbtheorem[number within=chapter]{example}{Example}{
+    remtitle,
+    label type=example,
+    thmbox={MaterialGrey700}{MaterialGrey50}
 }{ex}
 \newtcolorbox{remark}{
-    enhanced jigsaw,
-    breakable,
-    sharp corners,
-    borderline west={2pt}{0pt}{black!75!white},
-    boxrule=0pt,
     title=Remark,
-    fonttitle=\sffamily\bfseries,
-    coltitle=black,
-    attach title to upper={\quad},
-    parbox=false,
-    before skip=1.5em,
-    after skip=1.5em
+    remtitle,
+    thmbox={MaterialGreen700}{MaterialGreen50}
 }
 
 \crefname{def}{definition}{definitions}
@@ -149,18 +170,19 @@
 % Fix theorem spacing
 \makeatletter
 \def\thm@space@setup{%
-  \thm@preskip=\parskip \thm@postskip=0pt
+    \thm@preskip=\parskip \thm@postskip=0pt
 }
+\makeatother
 
 % Exercises
 \newenvironment{exercises}
     {\begin{enumerate}[font=\sffamily\bfseries]}
     {\end{enumerate}}
 
-% FIGURES
+
+% FIGURES =====================================================================
 \usepackage{caption}
 \usepackage{import}
-\usepackage{xifthen}
 \usepackage{pdfpages}
 \usepackage{transparent}
     
@@ -171,25 +193,29 @@
 \captionsetup{
     format=plain,
     labelsep=quad,
-    labelfont={bf,sf},
+    labelfont={sf,bf},
     font=sf
 }
-\numberwithin{figure}{section}
+\numberwithin{figure}{chapter}
 
 
-% TITLE AND SECTION STYLING PACKAGES
+% TITLE AND SECTION STYLING PACKAGES ====================================================
+\usepackage{etoolbox}
 \usepackage{titling}
 \usepackage{titleps}
 \usepackage{sectsty}
 
-% Headers and fonts
+% Headers
 \newpagestyle{main}[\sffamily]{
-    \setheadrule{.7pt}%
-    \sethead{\chaptername\ \thechapter}{}{\chaptertitle}
-    \setfoot{}{\thepage}{}
+    \sethead
+    [\chaptername\ \thechapter][\chaptertitle][\bfseries\thepage]%
+    {\S\thesection}{\sectiontitle}{\bfseries\thepage}
 }
+\patchcmd{\tableofcontents}{plain}{empty}{}{}
+\patchcmd{\part}{plain}{empty}{}{}
+\patchcmd{\chapter}{plain}{empty}{}{}
 
-% Set title page and section headings to sans serif
+% Sans serif titles and section headings
 \pretitle{\begin{center}\LARGE\sffamily}
 \posttitle{\par\end{center}\vskip 0.5em}
 \preauthor{\begin{center}
@@ -198,7 +224,21 @@
 \postauthor{\end{tabular}\par\end{center}}
 
 \allsectionsfont{\sffamily}
+\sectionfont{\sffamily\sectionrule{0pt}{0pt}{-1ex}{1pt}}
 \renewcommand{\abstractname}{\textsf{Introduction}}
+
+
+% TABLE OF CONTENTS ===========================================================
+% \usepackage{tocloft}
+% \renewcommand{\cfttoctitlefont}{\sffamily}
+% \renewcommand{\cftpartfont}{\sffamily}
+% \renewcommand{\cftpartpagefont}{\sffamily}
+% \renewcommand{\cftchapfont}{\sffamily}
+% \renewcommand{\cftchappagefont}{\sffamily}
+% \renewcommand{\cftsecfont}{\sffamily}
+% \renewcommand{\cftsecpagefont}{\sffamily}
+% \renewcommand{\cftsubsecfont}{\sffamily}
+% \renewcommand{\cftsubsecpagefont}{\sffamily}
 
 
 % C'est moi!


### PR DESCRIPTION
Theorem environments now have a wrapper that allow the mandatory title and label to be supplied as optional key-value pairs. Set comprehension command now takes an optional argument for the variable separate from the predicate. Changed bold text to italics when emphasizing. Theorem boxes and headers look nicer. Minor rewrites for clarity.